### PR TITLE
chore: configure d1 database for worker deployment

### DIFF
--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -10,7 +10,7 @@ crons = ["0 * * * *"]
 [[d1_databases]]
 binding = "DB"
 database_name = "bat-db"
-database_id = "placeholder-replace-with-real-id"
+database_id = "89d4d080-3f18-4a40-a118-9f97c5cce2ae"
 
 [vars]
 ENVIRONMENT = "development"
@@ -23,8 +23,8 @@ name = "bat-worker"
 
 [[env.production.d1_databases]]
 binding = "DB"
-database_name = "bat-db-prod"
-database_id = "placeholder-replace-with-prod-id"
+database_name = "bat-db"
+database_id = "89d4d080-3f18-4a40-a118-9f97c5cce2ae"
 
 [env.production.vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Summary
- Replace placeholder D1 database IDs in `wrangler.toml` with real `bat-db` instance (`89d4d080-3f18-4a40-a118-9f97c5cce2ae`, APAC region)

## What was done
- Created D1 database `bat-db` via CLI
- Applied 2 migrations (5 tables created)
- Deployed worker to https://bat-worker.lizheng.workers.dev
- Verified health endpoints responding correctly