### PR TITLE
fix(ui): Button outline + inline input remove border-input

### DIFF
--- a/packages/dashboard/src/components/host-allowed-ports.tsx
+++ b/packages/dashboard/src/components/host-allowed-ports.tsx
@@ -207,7 +207,7 @@ export function AllowedPortsPanel({ hostId, hostAlerts }: AllowedPortsPanelProps
 														}
 													}}
 													disabled={adding}
-													className="h-6 flex-1 rounded border border-input bg-background px-2 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+													className="h-6 flex-1 rounded border border-border bg-secondary hover:border-foreground/20 px-2 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
 													maxLength={200}
 												/>
 												<button
@@ -256,7 +256,7 @@ export function AllowedPortsPanel({ hostId, hostAlerts }: AllowedPortsPanelProps
 							value={portInput}
 							onChange={(e) => setPortInput(e.target.value)}
 							disabled={adding}
-							className="h-8 w-20 rounded-md border border-input bg-background px-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+							className="h-8 w-20 rounded-md border border-border bg-secondary hover:border-foreground/20 px-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
 							min={1}
 							max={65535}
 						/>
@@ -272,7 +272,7 @@ export function AllowedPortsPanel({ hostId, hostAlerts }: AllowedPortsPanelProps
 								}
 							}}
 							disabled={adding}
-							className="h-8 flex-1 rounded-md border border-input bg-background px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+							className="h-8 flex-1 rounded-md border border-border bg-secondary hover:border-foreground/20 px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
 							maxLength={200}
 						/>
 						<button

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
 				destructive:
 					"bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
-					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+					"border border-border bg-secondary shadow-xs hover:bg-accent hover:text-accent-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 				link: "text-primary underline-offset-4 hover:underline",


### PR DESCRIPTION
Closes #5

- Button outline: remove `dark:bg-input/30 dark:border-input`
- host-allowed-ports.tsx: inline input `border-input bg-background` → `border-border bg-secondary`

Per Basalt B05-3.