### PR TITLE
fix(ui): migrate remaining inputs from border-input to border-border

### DIFF
--- a/packages/dashboard/src/app/settings/webhooks/page.tsx
+++ b/packages/dashboard/src/app/settings/webhooks/page.tsx
@@ -131,7 +131,7 @@ export default function WebhookSettingsPage() {
 								<select
 									value={selectedHostId}
 									onChange={(e) => setSelectedHostId(e.target.value)}
-									className="h-8 text-sm flex-1 rounded-md border border-input bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="h-8 text-sm flex-1 rounded-md border border-border bg-secondary hover:border-foreground/20 px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<option value="">Select a host...</option>
 									{availableHosts.map((h) => (

--- a/packages/dashboard/src/app/tags/page.tsx
+++ b/packages/dashboard/src/app/tags/page.tsx
@@ -136,7 +136,7 @@ export default function TagsPage() {
 									placeholder="New tag name…"
 									value={newName}
 									onChange={(e) => setNewName(e.target.value)}
-									className="h-8 text-sm flex-1 rounded-md border border-input bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="h-8 text-sm flex-1 rounded-md border border-border bg-secondary hover:border-foreground/20 px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 									maxLength={32}
 								/>
 								<Button
@@ -231,7 +231,7 @@ function TagRow({
 						<input
 							value={editName}
 							onChange={(e) => onEditNameChange(e.target.value)}
-							className="h-7 text-sm w-40 rounded-md border border-input bg-background px-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							className="h-7 text-sm w-40 rounded-md border border-border bg-secondary hover:border-foreground/20 px-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							maxLength={32}
 						/>
 						<Button type="submit" size="sm" variant="ghost" className="h-7 text-xs">

--- a/packages/dashboard/src/components/host-tags-panel.tsx
+++ b/packages/dashboard/src/components/host-tags-panel.tsx
@@ -203,7 +203,7 @@ export function HostTagsPanel({ hostId }: HostTagsPanelProps) {
 									onBlur={handleBlur}
 									onKeyDown={handleKeyDown}
 									disabled={adding}
-									className="h-8 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+									className="h-8 w-full rounded-md border border-border bg-secondary hover:border-foreground/20 px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
 									maxLength={32}
 								/>
 							</div>


### PR DESCRIPTION
Closes #5 (remaining occurrences)

Migrate the last 4 inline inputs still using `border-input bg-background` to `border-border bg-secondary hover:border-foreground/20` per Basalt B05-3.

Files:
- `packages/dashboard/src/app/settings/webhooks/page.tsx`
- `packages/dashboard/src/app/tags/page.tsx` (×2)
- `packages/dashboard/src/components/host-tags-panel.tsx`

After this change, zero `border-input` occurrences remain in `packages/dashboard/src/`.