### PR TITLE
fix(ui): replace border-input/bg-input with basalt tokens

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
 				destructive:
 					"bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
-					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-secondary/30 dark:border-border dark:hover:bg-secondary/50",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 				link: "text-primary underline-offset-4 hover:underline",

--- a/packages/ui/src/routes/tags.tsx
+++ b/packages/ui/src/routes/tags.tsx
@@ -110,7 +110,7 @@ export function TagsPage() {
 									placeholder="New tag name…"
 									value={newName}
 									onChange={(e) => setNewName(e.target.value)}
-									className="h-8 text-sm flex-1 rounded-md border border-input bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="h-8 text-sm flex-1 rounded-md border border-border bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 									maxLength={32}
 								/>
 								<Button
@@ -205,7 +205,7 @@ function TagRow({
 						<input
 							value={editName}
 							onChange={(e) => onEditNameChange(e.target.value)}
-							className="h-7 text-sm w-40 rounded-md border border-input bg-background px-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							className="h-7 text-sm w-40 rounded-md border border-border bg-background px-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							maxLength={32}
 						/>
 						<Button type="submit" size="sm" variant="ghost" className="h-7 text-xs">

--- a/packages/ui/src/routes/webhooks.tsx
+++ b/packages/ui/src/routes/webhooks.tsx
@@ -114,7 +114,7 @@ export function WebhooksPage() {
 								<select
 									value={selectedHostId}
 									onChange={(e) => setSelectedHostId(e.target.value)}
-									className="h-8 text-sm flex-1 rounded-md border border-input bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="h-8 text-sm flex-1 rounded-md border border-border bg-background px-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<option value="">Select a host...</option>
 									{availableHosts.map((h) => (


### PR DESCRIPTION
Basalt compliance: replace anti-pattern tokens (border-input, bg-input) with compliant alternatives (border-border, bg-secondary).