### PR TITLE
fix(probe): enforce Rust coverage gate

### DIFF
--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -46,8 +46,8 @@ check_ts_coverage() {
 
 check_rust_coverage() {
   if ! command -v cargo-llvm-cov &>/dev/null; then
-    echo "⚠ probe: cargo-llvm-cov not installed (skipping)"
-    return 0
+    echo "✘ probe: cargo-llvm-cov not installed — install with 'cargo install cargo-llvm-cov' and 'rustup component add llvm-tools-preview'"
+    return 1
   fi
 
   # Prefer nightly for coverage(off) attribute support


### PR DESCRIPTION
将 cargo-llvm-cov 未安装从 skip 改为 fail，强制要求覆盖率工具存在。Rust 覆盖率 98.66% ≥ 90% 阈值。