### PR TITLE
fix(probe): use Duration::from_mins for clippy::duration_suboptimal_units

### DIFF
--- a/probe/src/collectors/tier2/disk_deep.rs
+++ b/probe/src/collectors/tier2/disk_deep.rs
@@ -145,7 +145,7 @@ pub fn parse_size_string(s: &str) -> Option<u64> {
 pub async fn collect_disk_deep_scan() -> DiskDeepScanInfo {
     use std::time::Duration;
 
-    const DISK_TIMEOUT: Duration = Duration::from_secs(120);
+    const DISK_TIMEOUT: Duration = Duration::from_mins(2);
 
     // Phase 1: du (heaviest I/O — sequential, low priority)
     let du_result =


### PR DESCRIPTION
## Problem

CI is red on `main` since commit `d6d9521` (release v2.0.4): the Probe (Rust) job's `G1: Clippy lint` step fails with `-D warnings` enforcement:

```
error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
  --> src/collectors/tier2/disk_deep.rs:148:36
148 |     const DISK_TIMEOUT: Duration = Duration::from_secs(120);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
help: try using from_mins
148 -     const DISK_TIMEOUT: Duration = Duration::from_secs(120);
148 +     const DISK_TIMEOUT: Duration = Duration::from_mins(2);
```

Lint: `clippy::duration_suboptimal_units` (new in clippy 1.96).

## Fix

Apply clippy's suggested rewrite — same value (120 s = 2 min), more readable.

## Verification

```
cd probe && cargo clippy -- -D warnings
# Finished `dev` profile target(s) in 23.81s ✅
```

## Surfaced by

🍊 lulo OSS patrol 2026-06-05 19:38 — Tier 1 auto-fix (single-line clippy suggestion with exact rewrite).
