### PR TITLE
chore(deps): bump better-sqlite3 + @cloudflare/workers-types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@biomejs/biome": "^2.5.0",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^4.1.8",
-        "better-sqlite3": "^12.10.0",
+        "better-sqlite3": "^12.10.1",
         "husky": "^9.1.0",
         "lint-staged": "^17.0.7",
         "picomatch": "^4.0.4",
@@ -638,7 +638,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -86,7 +86,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260612.1",
+        "@cloudflare/workers-types": "4.20260613.1",
         "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
         "wrangler": "4.100.0",
@@ -158,7 +158,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260611.1", "", { "os": "win32", "cpu": "x64" }, "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260612.1", "", {}, "sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260613.1", "", {}, "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@biomejs/biome": "^2.5.0",
 		"@types/better-sqlite3": "^7.6.13",
 		"@vitest/coverage-v8": "^4.1.8",
-		"better-sqlite3": "^12.10.0",
+		"better-sqlite3": "^12.10.1",
 		"husky": "^9.1.0",
 		"lint-staged": "^17.0.7",
 		"picomatch": "^4.0.4",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
 		"jose": "^6.2.3"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "4.20260612.1",
+		"@cloudflare/workers-types": "4.20260613.1",
 		"@types/bun": "^1.3.14",
 		"typescript": "^6.0.3",
 		"wrangler": "4.100.0"


### PR DESCRIPTION
## Summary

- bump `better-sqlite3` 12.10.0 → 12.10.1 (root devDependency, patch)
- bump `@cloudflare/workers-types` 4.20260612.1 → 4.20260613.1 (packages/worker devDependency, dated)

## Validation

- ✅ `bun run typecheck` (5/5 packages, including forced worker re-run)
- ✅ `bun run test` — 1339 unit tests + 637 rust tests
- ✅ `bun run lint` — 0 errors
- ✅ pre-commit (gitleaks / routes / pages gates) on both commits
- ✅ pre-push L2 E2E — 19 files / 168 tests, G2 security gate clean

Closes nocoo/bat#59
Closes nocoo/bat#58