### PR TITLE
build(deps): bump @cloudflare/workers-types & lint-staged

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,7 +86,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260619.1",
+        "@cloudflare/workers-types": "4.20260620.1",
         "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
         "wrangler": "4.103.0",
@@ -159,7 +159,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260619.1", "", {}, "sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "better-sqlite3": "^12.11.1",
         "husky": "^9.1.0",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "^17.0.8",
         "picomatch": "^4.0.4",
         "turbo": "2.9.17",
         "typescript": "^6.0.3",
@@ -767,7 +767,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
+    "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
 
     "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@vitest/coverage-v8": "^4.1.9",
 		"better-sqlite3": "^12.11.1",
 		"husky": "^9.1.0",
-		"lint-staged": "^17.0.7",
+		"lint-staged": "^17.0.8",
 		"picomatch": "^4.0.4",
 		"turbo": "2.9.17",
 		"typescript": "^6.0.3",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
 		"jose": "^6.2.3"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "4.20260619.1",
+		"@cloudflare/workers-types": "4.20260620.1",
 		"@types/bun": "^1.3.14",
 		"typescript": "^6.0.3",
 		"wrangler": "4.103.0"


### PR DESCRIPTION
## Summary

Weekly dependency bumps surfaced by the choko deps autopilot (Multica STU-1029). Both are `devDependencies` with no runtime impact.

- `@cloudflare/workers-types` `4.20260619.1` → `4.20260620.1` (minor, `packages/worker`) — closes #93
- `lint-staged` `17.0.7` → `17.0.8` (patch, root) — closes #94

Each upgrade is one atomic commit; `lint-staged` keeps the existing caret range strategy (`^17.0.8`), lockfile resolves to `17.0.8`.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck --force` (5/5 tasks)
- [x] `bunx turbo run test --filter='!@bat/cli'` (1339 unit tests)
- [x] `bun run test:e2e` (L2, 168 tests across 19 files)
- [x] `bun run lint` (Biome, only schema info)
- [x] pre-push: L2 + G2 (osv-scanner JS/Rust, gitleaks) ✔
