### PR TITLE
build(deps): bump @cloudflare/workers-types from 4.20260620.1 to 4.20260621.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,7 +86,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260620.1",
+        "@cloudflare/workers-types": "4.20260621.1",
         "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
         "wrangler": "4.103.0",
@@ -159,7 +159,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
 		"jose": "^6.2.3"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "4.20260620.1",
+		"@cloudflare/workers-types": "4.20260621.1",
 		"@types/bun": "^1.3.14",
 		"typescript": "^6.0.3",
 		"wrangler": "4.103.0"


### PR DESCRIPTION
## Summary

Bumps `@cloudflare/workers-types` from `4.20260620.1` to `4.20260621.1` in `packages/worker` (devDependencies).

## Verification

- ✔ `bun run typecheck` — 5/5 tasks passed
- ✔ `bun run test` — TS 1339 passed / Rust 637 passed
- ✔ `bun run build`
- ✔ pre-commit gate (coverage / lint-staged / gitleaks / routes / pages) passed
- ✔ pre-push G2 security gate passed

Closes nocoo/bat#96
