### PR TITLE
build(deps): bump quinn-proto (security) + swr patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
         "react-dom": "^19.2.7",
         "react-router": "8.0.1",
         "recharts": "^3.8.1",
-        "swr": "2.4.1",
+        "swr": "2.4.2",
         "tailwind-merge": "^3.6.0",
       },
       "devDependencies": {
@@ -897,7 +897,7 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
+    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,7 @@
 		"react-dom": "^19.2.7",
 		"react-router": "8.0.1",
 		"recharts": "^3.8.1",
-		"swr": "2.4.1",
+		"swr": "2.4.2",
 		"tailwind-merge": "^3.6.0"
 	},
 	"devDependencies": {

--- a/probe/Cargo.lock
+++ b/probe/Cargo.lock
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

依赖升级批次（2026-06-23），同仓 patch 合并为一个 PR：

- 🔒 **quinn-proto 0.11.14 → 0.11.15** — 修复 GHSA-4w2j-m93h-cj5j（QUIC 远程内存耗尽，CVSS AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H）。间接依赖，通过 `cargo update -p quinn-proto` 拉新版。
- **swr 2.4.1 → 2.4.2** (`packages/ui`) — patch 升级，`bun add swr@2.4.2`。

每项独立原子提交。

## Verification

- ✅ `cargo check` + `cargo test` (probe) — 637 passed
- ✅ `bun run test` (packages/ui) — 264 passed
- ✅ Pre-push L2 E2E (`@bat/worker test:e2e`) — 168 passed
- ✅ Pre-push G2 Security — osv-scanner (Rust+JS) clean, gitleaks clean
- ✅ Pre-commit L1+G1 — coverage / typecheck / lint / routes / pages 全过

## Closes

- Closes #98
- Closes #99
