### PR TITLE
build(deps): bump @cloudflare/workers-types from 4.20260625.1 to 4.20260626.1 in packages/worker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@bat/cli",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "bin": {
         "bat-cli": "./dist/bin/bat-cli.js",
       },
@@ -38,14 +38,14 @@
     },
     "packages/shared": {
       "name": "@bat/shared",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "devDependencies": {
         "typescript": "^6.0.3",
       },
     },
     "packages/ui": {
       "name": "@bat/ui",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "dependencies": {
         "@bat/shared": "workspace:*",
         "@radix-ui/react-avatar": "^1.2.0",
@@ -79,14 +79,14 @@
     },
     "packages/worker": {
       "name": "@bat/worker",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "dependencies": {
         "@bat/shared": "workspace:*",
         "hono": "4.12.27",
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260625.1",
+        "@cloudflare/workers-types": "4.20260626.1",
         "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
         "wrangler": "4.105.0",
@@ -159,7 +159,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260625.1", "", {}, "sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260626.1", "", {}, "sha512-fBnpQyFRS3Ce1l2IUd3k+aUxgy/7VMlVXF4F672/eSrpXFeezCy3Ha6Z2uTyGgqu9sGvQPOj8nqKBv2yeI+ciw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
 		"jose": "^6.2.3"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "4.20260625.1",
+		"@cloudflare/workers-types": "4.20260626.1",
 		"@types/bun": "^1.3.14",
 		"typescript": "^6.0.3",
 		"wrangler": "4.105.0"


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` from `4.20260625.1` to `4.20260626.1` in `packages/worker` (devDependency).

Tracks upstream Workers Types daily release.

Closes nocoo/bat#115

## Verification

- `bun run typecheck` ✅ (5/5 packages)
- `bun run lint` ✅ (344 files, no warnings)
- `bun run test` ✅ (worker 1339/1339, probe 637/637)
- `bun turbo test:e2e --filter=@bat/worker` ✅ (19 files / 168 tests)
- Pre-commit (L1 + G1) ✅
- Pre-push (L2 + G2 osv-scanner + gitleaks) ✅

## Diff scope

- `packages/worker/package.json` — devDependency version bump
- `bun.lock` — lockfile sync (workspace versions also normalized to `2.1.0` matching current `package.json`)
