### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
Adds root `.npmrc` supply-chain baseline: pin official npm registry, enforce lockfile integrity (`save-exact` + `package-lock`), `engine-strict`, and `audit=true` with `audit-level=high`. Silences funding noise.

Scope: root `.npmrc` only, 21 lines. No other files touched.

Issue: [STU-1540](mention://issue/7f276d51-1734-4faf-8a17-e7ad455b07ce)